### PR TITLE
Configurable option to sleep between consecutive requests from the same worker

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ var NumQueryWorkers int
 var NumRedirects int
 var Srcip string
 var IgnoreLocalResolvers bool
+var MeasurementSeparation int
 
 var WhoamiEndpoints = [...]string{
 	"o-o.myaddr.l.google.com",
@@ -37,7 +38,8 @@ func init() {
 	flag.StringVar(&OutputConnFile, "output-conn-file", "-", "Output File for writing TCP, TLS and HTTP connection responses (default - stdout)")
 	flag.StringVar(&OutputFailedConnFile, "output-failed-conn-file", "failed_conn.csv", "Output File for writing domain,ip pairs with failed tcp/tls connections, used to run traceroutes (default - failed_conn.csv)")
 	flag.StringVar(&Module, "module", "full", "Module to run (can be dns, tcp or full (DNS + TCP) (default - full)")
-	flag.IntVar(&NumWorkers, "num-workers", 100, "Number of vantage points to perform measurements to at any moment (default - 100)")
+	flag.IntVar(&NumWorkers, "num-workers", 100, "Number of parallel workers to perform measurements at any moment (default - 100)")
+	flag.IntVar(&MeasurementSeparation, "measurement-separation", 1, "Time (in seconds) to wait between consecutive probes by the same worker (default - 1)")
 	flag.IntVar(&NumQueryWorkers, "num-query-workers", 3, "Number of qeuries to perform to each resolver at any moment (default - 3)")
 	flag.IntVar(&NumRedirects, "num-redirects", 10, "Number of redirects to follow for an HTTP request (default 10)")
 	flag.StringVar(&Srcip, "src-ip", "", "Source IP address to use (will use default if unspecified)")

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -167,7 +167,7 @@ func QueryWorker(client *dns.Client, resolver InputDNSResolver, domains <-chan s
 					if parsed.Err == "null" {
 						break
 					}
-					time.Sleep(1 * time.Second)
+					time.Sleep(time.Duration(config.MeasurementSeparation) * time.Second)
 				}
 			} else {
 				reply.Error = "Iterative error"

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -184,7 +184,7 @@ func QueryWorker(client *dns.Client, resolver InputDNSResolver, domains <-chan s
 				if parsed.Err == "null" {
 					break
 				}
-				time.Sleep(1 * time.Second)
+				time.Sleep(time.Duration(config.MeasurementSeparation) * time.Second)
 			}
 		}
 		reply.EndTime = time.Now().Round(0).String()

--- a/tcp/tcp.go
+++ b/tcp/tcp.go
@@ -275,7 +275,7 @@ func RequestWorker(jobs <-chan InputServer, results chan<- *Response, numRedirec
 			}
 			retryErrors = append(retryErrors, respSNI.Error)
 			respSNI.RetryErrors = retryErrors
-			time.Sleep(1 * time.Second)
+			time.Sleep(time.Duration(config.MeasurementSeparation) * time.Second)
 		}
 		response.Responses = append(response.Responses, *respSNI)
 


### PR DESCRIPTION
This will allow an indirect way to control the speed of the measurements. For example, if the measurement separation is 3 seconds and there are 100 workers, there will be a maximum of 100 measurements every 3 seconds. 